### PR TITLE
fix: reposition footer on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix url to doc/presenting.txt
 - README: list of keymaps was broken
+- Footer stays in place when resizing
 
 ### Removed
 

--- a/lua/presenting/init.lua
+++ b/lua/presenting/init.lua
@@ -197,12 +197,13 @@ end
 ---Resize the slide window.
 Presenting.resize = function()
   if not H.in_presenting_mode() then return end
-  if (Presenting._state.background_win == nil) or (Presenting._state.slide_win == nil) then
+  if (Presenting._state.background_win == nil) or (Presenting._state.slide_win == nil) or (Presenting._state.footer_win == nil) then
     return
   end
 
   local window_config = H.get_win_configs()
   vim.api.nvim_win_set_config(Presenting._state.background_win, window_config.background)
+  vim.api.nvim_win_set_config(Presenting._state.footer_win, window_config.footer)
   vim.api.nvim_win_set_config(Presenting._state.slide_win, window_config.slide)
 end
 


### PR DESCRIPTION
## 📃 Summary

<!-- Provide some context about the pull request, it makes the review easier. -->
Without this, the footer stays in place while the other two windows are correctly resized and repositioned.

To trigger this, adjust font size up and down in a maximised terminal window - the footer would only ever move up, never down again. Now it does.

<!-- 
## 📸 Preview

If there's a visual impact to your change, please provide a screenshot. You can directly upload it to GitHub by dragging in this text area. -->

## 📝 Checklist

- [ ] I ran `make all` locally and checked for errors.
- [X] I have updated the `CHANGELOG.md` file.
