### PR TITLE
Add option not to keep separator

### DIFF
--- a/doc/presenting.txt
+++ b/doc/presenting.txt
@@ -41,6 +41,9 @@ Default values:
       adoc = "^==+ ",
       asciidoctor = "^==+ ",
     },
+    -- Keep the separator, useful if you're parsing based on headings.
+    -- If you want to parse on a non-heading separator, e.g. `---` set this to false.
+    keep_separator = true,
     keymaps = {
       -- These are local mappings for the open slide buffer.
       -- Disable existing keymaps by setting them to `nil`.

--- a/lua/presenting/init.lua
+++ b/lua/presenting/init.lua
@@ -39,7 +39,7 @@ end
 Presenting.config = {
   options = {
     -- The width of the slide buffer.
-    width = 60,
+    width = 90,
   },
   separator = {
     -- Separators for different filetypes.
@@ -50,6 +50,7 @@ Presenting.config = {
     adoc = "^==+ ",
     asciidoctor = "^==+ ",
   },
+  keep_separator = true,
   keymaps = {
     -- These are local mappings for the open slide buffer.
     -- Disable existing keymaps by setting them to `nil`.
@@ -57,8 +58,8 @@ Presenting.config = {
     ["n"] = function() Presenting.next() end,
     ["p"] = function() Presenting.prev() end,
     ["q"] = function() Presenting.quit() end,
-    ["f"] = function() Presenting.first() end,
-    ["l"] = function() Presenting.last() end,
+    ["F"] = function() Presenting.first() end,
+    ["L"] = function() Presenting.last() end,
     ["<CR>"] = function() Presenting.next() end,
     ["<BS>"] = function() Presenting.prev() end,
   },
@@ -125,7 +126,7 @@ Presenting.start = function(separator)
 
   -- content of slides
   local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-  Presenting._state.slides = H.parse_slides(lines, separator)
+  Presenting._state.slides = H.parse_slides(lines, separator, Presenting.config.keep_separator)
   Presenting._state.n_slides = #Presenting._state.slides
 
   H.create_slide_view(Presenting._state)
@@ -304,7 +305,7 @@ end
 ---@param separator string
 ---@return table
 ---@private
-H.parse_slides = function(lines, separator)
+H.parse_slides = function(lines, separator, keep_separator)
   -- TODO: isn't there a split() in lua that keeps the separator?
   local slides = {}
   local slide = {}
@@ -312,8 +313,12 @@ H.parse_slides = function(lines, separator)
     if line:match(separator) then
       if #slide > 0 then table.insert(slides, table.concat(slide, "\n")) end
       slide = {}
+      if keep_separator then
+        table.insert(slide, line)
+      end
+    else
+      table.insert(slide, line)
     end
-    table.insert(slide, line)
   end
   table.insert(slides, table.concat(slide, "\n"))
 

--- a/lua/presenting/init.lua
+++ b/lua/presenting/init.lua
@@ -39,7 +39,7 @@ end
 Presenting.config = {
   options = {
     -- The width of the slide buffer.
-    width = 90,
+    width = 60,
   },
   separator = {
     -- Separators for different filetypes.
@@ -50,6 +50,8 @@ Presenting.config = {
     adoc = "^==+ ",
     asciidoctor = "^==+ ",
   },
+  -- Keep the separator, useful if you're parsing based on headings.
+  -- If you want to parse on a non-heading separator, e.g. `---` set this to false.
   keep_separator = true,
   keymaps = {
     -- These are local mappings for the open slide buffer.
@@ -58,8 +60,8 @@ Presenting.config = {
     ["n"] = function() Presenting.next() end,
     ["p"] = function() Presenting.prev() end,
     ["q"] = function() Presenting.quit() end,
-    ["F"] = function() Presenting.first() end,
-    ["L"] = function() Presenting.last() end,
+    ["f"] = function() Presenting.first() end,
+    ["l"] = function() Presenting.last() end,
     ["<CR>"] = function() Presenting.next() end,
     ["<BS>"] = function() Presenting.prev() end,
   },


### PR DESCRIPTION
Great plugin! I've been looking for a Neovim native slideshow for a while ...

Switching from `lookatme` and `slides` to `presenting.nvim` by not keeping the `---` separator allows me to use the same file with the three. 

In addition, the option not to keep the separator makes it easier to organize slides with multiple headings in them.