### PR TITLE
Bugfix check if windows exist before resizing

### DIFF
--- a/lua/presenting/init.lua
+++ b/lua/presenting/init.lua
@@ -202,18 +202,24 @@ end
 ---Resize the slide window.
 Presenting.resize = function()
   if not H.in_presenting_mode() then return end
+  local s = Presenting._state
   if
-    (Presenting._state.background_win == nil)
-    or (Presenting._state.slide_win == nil)
-    or (Presenting._state.footer_win == nil)
+    not (
+      s.background_win
+      and vim.api.nvim_win_is_valid(s.background_win)
+      and s.slide_win
+      and vim.api.nvim_win_is_valid(s.slide_win)
+      and s.footer_win
+      and vim.api.nvim_win_is_valid(s.footer_win)
+    )
   then
     return
   end
 
   local window_config = H.get_win_configs()
-  vim.api.nvim_win_set_config(Presenting._state.background_win, window_config.background)
-  vim.api.nvim_win_set_config(Presenting._state.footer_win, window_config.footer)
-  vim.api.nvim_win_set_config(Presenting._state.slide_win, window_config.slide)
+  vim.api.nvim_win_set_config(s.background_win, window_config.background)
+  vim.api.nvim_win_set_config(s.footer_win, window_config.footer)
+  vim.api.nvim_win_set_config(s.slide_win, window_config.slide)
 end
 
 Presenting.dev_mode = function()


### PR DESCRIPTION
## 📃 Summary
With the nvim command:
`:q`

An error happens:

```
Error detected while processing WinResized Autocommands for "*": Error executing lua callback: .../share/nvim/lazy/presenting.nvim/lua/presenting/init.lua:216: Invalid window id: 1003 stack traceback: [C]: in function 'nvim_win_set_config' .../share/nvim/lazy/presenting.nvim/lua/presenting/init.lua:216: in function 'resize' .../share/nvim/lazy/presenting.nvim/lua/presenting/init.lua:31: in function <.../share/nvim/lazy /presenting.nvim/lua/presenting/init.lua:31>
```

Small fix that checks windows existence first before resizing. Even though, most user behavior should be to quit by doing:
`q`
