### PR TITLE
(fix) fix misspelling of 'overwrite'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix url to doc/presenting.txt
 - README: list of keymaps was broken
 - Footer stays in place when resizing
+- Fix misspelling of 'overwrite' in documentation
 
 ### Removed
 

--- a/doc/presenting.txt
+++ b/doc/presenting.txt
@@ -34,7 +34,7 @@ Default values:
     },
     separator = {
       -- Separators for different filetypes.
-      -- You can add your own or oberwrite existing ones.
+      -- You can add your own or overwrite existing ones.
       -- Note: separators are lua patterns, not regexes.
       markdown = "^#+ ",
       org = "^*+ ",

--- a/lua/presenting/init.lua
+++ b/lua/presenting/init.lua
@@ -43,7 +43,7 @@ Presenting.config = {
   },
   separator = {
     -- Separators for different filetypes.
-    -- You can add your own or oberwrite existing ones.
+    -- You can add your own or overwrite existing ones.
     -- Note: separators are lua patterns, not regexes.
     markdown = "^#+ ",
     org = "^*+ ",


### PR DESCRIPTION
## 📃 Summary
Fix for a misspelling of `overwrite` in the documentation

## 📸 Preview


## 📝 Checklist

- [x] I ran `make all` locally and checked for errors.
- [x] I have updated the `CHANGELOG.md` file.
